### PR TITLE
DP-239 wrong version on container images

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -25,6 +25,7 @@ jobs:
       public: true
       public_image: ce/ignition-gazebo
       deploy: ${{ contains(github.ref, 'refs/heads/main') || contains(github.ref, 'refs/tags/v')}}
+      version: ${GITHUB_REF##*/}
       push_latest: ${{ contains(github.ref, 'refs/heads/main') || contains(github.ref, 'refs/tags/v') }}
       snyk_check: true
       platforms: linux/amd64, linux/arm64

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -17,6 +17,16 @@ on:
   release:
     types: [released]
 jobs:
+  context-verification:
+    name: Context Verification
+    runs-on: ubuntu-latest
+    steps:
+      - name: Echo Github Reference Context
+        run: |
+          echo "${GITHUB_REF##*/}"
+          echo "${{ github.ref }}"
+          echo "${{ github.ref_name }}"
+
   ignition-gazebo:
     uses: MOV-AI/.github/.github/workflows/docker-workflow.yml@v2
     with:

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -17,16 +17,6 @@ on:
   release:
     types: [released]
 jobs:
-  context-verification:
-    name: Context Verification
-    runs-on: ubuntu-latest
-    steps:
-      - name: Echo Github Reference Context
-        run: |
-          echo "${GITHUB_REF##*/}"
-          echo "${{ github.ref }}"
-          echo "${{ github.ref_name }}"
-
   ignition-gazebo:
     uses: MOV-AI/.github/.github/workflows/docker-workflow.yml@v2
     with:


### PR DESCRIPTION
Add 'version' input to docker image action.

Pipeline Run: https://github.com/MOV-AI/containers-ign-simulator/actions/runs/5764542054

Tag Version Generated: merge (as determined before by the github reference context)
Push Flag: False

-------------------------

- [x] Make sure you are opening from a **topic/feature/bugfix branch**
- [x] Ensure that the PR title represents the desired changes
- [x] Ensure that the PR description detail the desired changes
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue


[^note]:
    Put an `x` into the [ ] to show you have filled the information.
    The template comes from https://github.com/MOV-AI/.github/blob/master/.github/pull_request_template.md
    You can override it by creating .github/pull_request_template.md  in your own repository
