### PR TITLE
Feat: install recommended version of Gazebo on Focal - Garden

### DIFF
--- a/gazebo/Dockerfile
+++ b/gazebo/Dockerfile
@@ -17,18 +17,18 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 COPY ./gazebo/movai-entrypoint.sh /usr/local/bin/movai-entrypoint.sh
 
 ### Install ignition-fortress
-RUN wget --progress=dot:giga "https://packages.osrfoundation.org/gazebo.gpg" -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg && \
-    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null  && \
+RUN  wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg && \
+     echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null && \
     echo "Package: *" >> /etc/apt/preferences.d/ros-gazebo && \
     echo "Pin: origin packages.osrfoundation.org" >> /etc/apt/preferences.d/ros-gazebo && \
     echo "Pin-Priority: 1001" >> /etc/apt/preferences.d/ros-gazebo && \
-    apt-get update && \
-    apt-get install ignition-fortress=1.0.3-2~focal -y --no-install-recommends && \
+    apt-get update && apt-get install gz-garden=1.0.0-1~focal -y --no-install-recommends && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
 ### Set up plugin directories (add .keep to be not removed by deb package on uninstall)
     mkdir -p ${IGN_GAZEBO_SYSTEM_PLUGIN_PATH} && touch ${IGN_GAZEBO_SYSTEM_PLUGIN_PATH}/.keep && \
-    mkdir -p ${IGN_GUI_PLUGIN_PATH} && touch ${IGN_GUI_PLUGIN_PATH}/.keep
+    mkdir -p ${IGN_GUI_PLUGIN_PATH} && touch ${IGN_GUI_PLUGIN_PATH}/.keep && \
+    echo "alias ign='gz'" >> /root/.bashrc
 
 ### Set plugin env
 ENV IGN_GAZEBO_SYSTEM_PLUGIN_PATH=${IGN_GAZEBO_SYSTEM_PLUGIN_PATH}:${IGN_GAZEBO_SYSTEM_PLUGIN_PATH_USER}


### PR DESCRIPTION
As stated here we should now be using Garden: https://gazebosim.org/docs

![image](https://github.com/MOV-AI/containers-ign-simulator/assets/84147256/0bfed341-38d7-4a14-b96e-117bdafaa4d4)

Fixes:
- Install garden instead of fortress
- Create alias for ign for retrocompatibility